### PR TITLE
Variable trimed on setters/getters creation when default value set

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -86,7 +86,7 @@ function! PhpCreateSettersAndGetters() " {{{
     normal gg
     let l:properties = []
     while search(s:php_regex_member_line, 'eW') > 0
-        normal w"xyw
+        normal w"xye
         call add(l:properties, @x)
     endwhile
     for l:property in l:properties


### PR DESCRIPTION
Use case:
=======
````
<?php

class Test {
    private $var = false;
}
````

`<leader>sg`

Result before:
------------------
````
<?php

class Test {
    private $var = false;

    public function setVar ($var )
    {
        $this->var = $var;
    }

    public function getVar ()
    {
        return $this->var;
    }
}
````

Result after:
---------------
````
<?php

class Test {
    private $var = false;

    public function setVar($var)
    {
        $this->var = $var;
    }

    public function getVar()
    {
        return $this->var;
    }
}
````