### PR TITLE
Option to disable the user validation of getters/setters creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ If you want to disable the default mapping just add this line in your `~/.vimrc`
 let g:vim_php_refactoring_use_default_mapping = 0
 ```
 
+If you want to disable the user validation at the getter/setter creation, just add this line in your `~/.vimrc` file
+
+```
+let g:vim_php_refactoring_auto_validate = 1
+```
+
 ## Default Mappings
 
     nnoremap <unique> <Leader>rlv :call PhpRenameLocalVariable()<CR>

--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -16,6 +16,10 @@ endif
 if !exists('g:vim_php_refactoring_use_default_mapping')
     let g:vim_php_refactoring_use_default_mapping = 1
 endif
+
+if !exists('g:vim_php_refactoring_auto_validate')
+    let g:vim_php_refactoring_auto_validate = 0
+endif
 " }}}
 
 " Refactoring mapping {{{
@@ -92,8 +96,10 @@ function! PhpCreateSettersAndGetters() " {{{
     for l:property in l:properties
         let l:camelCaseName = substitute(l:property, '^_\?\(.\)', '\U\1', '')
         call s:PhpEchoError('Create set' . l:camelCaseName . '() and get' . l:camelCaseName . '()')
-        if inputlist(["0. No", "1. Yes"]) == 0
-            continue
+        if g:vim_php_refactoring_auto_validate == 0
+            if inputlist(["0. No", "1. Yes"]) == 0
+                continue
+            endif
         endif
         if search(s:php_regex_func_line . "set" . l:camelCaseName . '\>', 'n') == 0
             call s:PhpInsertMethod("public", "set" . l:camelCaseName, ['$' . substitute(l:property, '^_', '', '') ], "$this->" . l:property . " = $" . substitute(l:property, '^_', '', '') . ";\n")


### PR DESCRIPTION
Just put this on your `~/.vimrc` file:
```
let g:vim_php_refactoring_auto_validate = 1
```