### PR TITLE
Custom variable visibility

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -181,7 +181,11 @@ function! PhpExtractClassProperty() " {{{
     normal mr
     let l:name = expand('<cword>')
     call s:PhpReplaceInCurrentFunction('$' . l:name . '\>', '$this->' . l:name)
-    call s:PhpInsertProperty(l:name, "private")
+    let l:visibility = inputdialog("Visibility (default is private): ")
+    if empty(l:visibility)
+        let l:visibility =  'private'
+    endif
+    call s:PhpInsertProperty(l:name, l:visibility)
     normal `r
 endfunction
 " }}}
@@ -237,7 +241,11 @@ endfunction
 
 function! PhpCreateProperty() " {{{
     let l:name = inputdialog("Name of new property: ")
-    call s:PhpInsertProperty(l:name, "private")
+    let l:visibility = inputdialog("Visibility (default is private): ")
+    if empty(l:visibility)
+        let l:visibility =  'private'
+    endif
+    call s:PhpInsertProperty(l:name, l:visibility)
 endfunction
 " }}}
 


### PR DESCRIPTION
Hi,

This pull request add the option to set the visibility (private|protected|public|static|abstract) when creating a new class property and or when extracting a variable as a class property.
Default is still 'private' following your initial code.

Regards.