### PR TITLE
Custom method visibility

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -181,7 +181,11 @@ function! PhpExtractClassProperty() " {{{
     normal mr
     let l:name = expand('<cword>')
     call s:PhpReplaceInCurrentFunction('$' . l:name . '\>', '$this->' . l:name)
-    call s:PhpInsertProperty(l:name, "private")
+    let l:visibility = inputdialog("Visibility (default is private): ")
+    if empty(l:visibility)
+        let l:visibility =  'private'
+    endif
+    call s:PhpInsertProperty(l:name, l:visibility)
     normal `r
 endfunction
 " }}}
@@ -237,7 +241,11 @@ endfunction
 
 function! PhpCreateProperty() " {{{
     let l:name = inputdialog("Name of new property: ")
-    call s:PhpInsertProperty(l:name, "private")
+    let l:visibility = inputdialog("Visibility (default is private): ")
+    if empty(l:visibility)
+        let l:visibility =  'private'
+    endif
+    call s:PhpInsertProperty(l:name, l:visibility)
 endfunction
 " }}}
 

--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -196,6 +196,10 @@ function! PhpExtractMethod() range " {{{
         return
     endif
     let l:name = inputdialog("Name of new method: ")
+    let l:visibility = inputdialog("Visibility (default is private): ")
+    if empty(l:visibility)
+        let l:visibility =  'private'
+    endif
     normal gv"xdmr
     let l:middleLine = line('.')
     call search(s:php_regex_func_line, 'bW')
@@ -234,7 +238,7 @@ function! PhpExtractMethod() range " {{{
         exec "normal! Olist(" . join(l:output, ", ") . ") = $this->" . l:name . "(" . join(l:parameters, ", ") . ");\<ESC>=3="
         let l:return = "return array(" . join(l:output, ", ") . ");\<CR>"
     endif
-    call s:PhpInsertMethod("private", l:name, l:parametersSignature, @x . l:return)
+    call s:PhpInsertMethod(l:visibility, l:name, l:parametersSignature, @x . l:return)
     normal `r
 endfunction
 " }}}


### PR DESCRIPTION
Hi,

This follows my first pull request https://github.com/adoy/vim-php-refactoring-toolbox/pull/8

This one allows one to set the visibility (private|protected|public|static|abstract) of the extracted method.
Default is still 'private' following your initial code.

Regards.