### PR TITLE
Prevent reload

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -7,6 +7,11 @@
 " Version: 1.0.2
 "
 
+if exists('g:vim_php_refactoring_loaded')
+    finish
+endif
+let g:vim_php_refactoring_loaded = 1
+
 " Config {{{
 " VIM function to call to document the current line
 if !exists('g:vim_php_refactoring_phpdoc')


### PR DESCRIPTION
If we source the vimrc file while the plugin is already loaded, it'll be reloaded unnecessarily, and we'll get some annoying behavior from the editor, like errors and blank screen..
It's very simple prevent the plugin from being reloaded, like I just did. I think it's very helpful.

PS. sorry for my bad english.