### PR TITLE
Fluent documentation typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ To enable fluent setters add either of these lines to your `~/.vimrc` file
 " default is 0 -- disabled
 
 " to enable for all setters
-let g:vim_php_refactoring_fluent_setter = 1
+let g:vim_php_refactoring_make_setter_fluent = 1
 
 " to enable but be prompted when creating the setter
-let g:vim_php_refactoring_fluent_setter = 2
+let g:vim_php_refactoring_make_setter_fluent = 2
 ```
 
 


### PR DESCRIPTION
Documentation incorrectly had the fluent setting as vim_php_refactoring_fluent_setter instead of the programmed vim_php_refactoring_make_setter_fluent.