### PR TITLE
ExtractConst - Escapes the visual selection when extracting a constant and make it very nomagic

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -246,7 +246,7 @@ function! PhpExtractConst() " {{{
     endif
     let l:name = toupper(inputdialog("Name of new const: "))
     normal! mrgv"xy
-    call s:PhpReplaceInCurrentClass(@x, 'self::' . l:name)
+    call s:PhpReplaceInCurrentClass('\V' . escape(@x, '\\/'), 'self::' . l:name)
     call s:PhpInsertConst(l:name, @x)
     normal! `r
 endfunction


### PR DESCRIPTION
Hi,

I was trying to extract a date format and the plugin returns me an error.
The format contained slashes, therefore the substitue command let me knows there were some trailing chars.
So I thought, that when we want to extract a constant we don't need a substitution pattern, we just want to replace the selection as it is.