### PR TITLE
Add type hint and/or type comments to getters and setters

### DIFF
--- a/plugin/php-refactoring-toolbox.vim
+++ b/plugin/php-refactoring-toolbox.vim
@@ -55,7 +55,7 @@ if !exists('g:vim_php_refactoring_make_setter_fluent')
 endif
 
 if !exists('g:vim_php_refactoring_add_sg_types')
-    let g:vim_php_refactoring_add_sg_types = 0
+    let g:vim_php_refactoring_add_sg_types = 1
 endif
 " }}}
 


### PR DESCRIPTION
Add type hint and/or type comments to getters and setters

Note: phpstan can use both type hint and type comment (aka phpdoc) to specialize the type